### PR TITLE
Route all request to /api/* to api handler and Include request url in response

### DIFF
--- a/app.go
+++ b/app.go
@@ -111,10 +111,12 @@ func api(w http.ResponseWriter, req *http.Request) {
 		Hostname string      `json:"hostname,omitempty"`
 		IP       []string    `json:"ip,omitempty"`
 		Headers  http.Header `json:"headers,omitempty"`
+		URL      string      `json:"url,omitempty"`
 	}{
 		hostname,
 		[]string{},
 		req.Header,
+		req.URL.RequestURI(),
 	}
 
 	ifaces, _ := net.Interfaces()

--- a/app.go
+++ b/app.go
@@ -35,7 +35,7 @@ func main() {
 	http.HandleFunc("/echo", echoHandler)
 	http.HandleFunc("/bench", benchHandler)
 	http.HandleFunc("/", whoami)
-	http.HandleFunc("/api", api)
+	http.HandleFunc("/api/", api)
 	http.HandleFunc("/health", healthHandler)
 	fmt.Println("Starting up on port " + port)
 	if len(cert) > 0 && len(key) > 0 {


### PR DESCRIPTION
I used this for testing a reverse proxy, and it was extremely useful to see what the request url was when proxying arbitrary requests.