### PR TITLE
Document the 'wait' and 'unit' query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Tiny Go webserver that prints os information and HTTP request to output
 
 ### Paths
 
-- `/data?size=n`: creates a response with a size `n`.
+- `/data?size=n[&unit=u]`: creates a response with a size `n`. The unit of measure, if specified, accepts the following values: `KB`, `MB`, `GB`, `TB` (optional, default: `KB`).
 - `/echo`: webSocket echo.
 - `/bench`: always return the same response (`1`).
-- `/`: returns the whoami information (request and network information).
+- `/[?wait=d]`: returns the whoami information (request and network information). The optional `wait` query parameter can be provided to tell the server to wait before sending the response. The duration is expected in Go's [`time.Duration`](https://golang.org/pkg/time/#ParseDuration) format (e.g. `/?wait=100ms` to wait 100 milliseconds).
 - `/api`: returns the whoami information as JSON.
 - `/health`: heath check
     - `GET`, `HEAD`, ...: returns a response with the status code defined by the `POST`


### PR DESCRIPTION
The following very helpful query parameters exist but are not documented:
- `/data`: `unit=u`, to set the unit of measure
- `/` (whoami): `wait=d`, to specify time to wait before sending the response.