### PR TITLE
Add a name to be more human friendly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Tiny Go webserver that prints os information and HTTP request to output
 - `cert`: give me a certificate.
 - `key`: give me a key.
 - `port`: give me a port number. (default: 80)
+- `name`: give me a name. (it can be also defined with `WHOAMI_NAME` environment variable)
 
 ## Examples
 
@@ -62,4 +63,8 @@ $ curl -v http://localhost:80/health
 < HTTP/1.1 500 Internal Server Error
 < Date: Mon, 16 Sep 2019 22:52:40 GMT
 < Content-Length: 0
+```
+
+```console
+docker run -d -P -v ./certs:/certs --name iamfoo containous/whoami --cert /certs/cert.cer --key /certs/key.key
 ```

--- a/app.go
+++ b/app.go
@@ -31,11 +31,13 @@ const (
 var cert string
 var key string
 var port string
+var name string
 
 func init() {
 	flag.StringVar(&cert, "cert", "", "give me a certificate")
 	flag.StringVar(&key, "key", "", "give me a key")
 	flag.StringVar(&port, "port", "80", "give me a port number")
+	flag.StringVar(&name, "name", os.Getenv("WHOAMI_NAME"), "give me a name")
 }
 
 var upgrader = websocket.Upgrader{
@@ -147,6 +149,10 @@ func whoamiHandler(w http.ResponseWriter, req *http.Request) {
 		if err == nil {
 			time.Sleep(duration)
 		}
+	}
+
+	if name != "" {
+		_, _ = fmt.Fprintln(w, "Name:", name)
 	}
 
 	hostname, _ := os.Hostname()


### PR DESCRIPTION
```console
go run . --name 🧀 --port 8080
```

```console
$ curl localhost:8080
Name: 🧀
Hostname: containous-pc
IP: 127.0.0.1
IP: ::1
IP: 192.168.1.42
IP: fe80::661d:c5f4:a9da:be47
IP: 172.28.0.1
IP: 172.17.0.1
IP: fe80::42:78ff:fe20:b0e5
IP: 172.23.0.1
IP: fe80::42:77ff:fec9:9a5e
RemoteAddr: [::1]:34678
GET / HTTP/1.1
Host: localhost:8080
User-Agent: curl/7.68.0
Accept: */*
```

Closes #25
